### PR TITLE
Update json-rpc to get better SSL errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "fguillot/json-rpc": "1.0.0",
+        "fguillot/json-rpc": "1.2.3",
 		"ext-curl": "*"
     }
 }


### PR DESCRIPTION
The current version of json-rpc in use has several bugs surrounding SSL and bad error handling. The result is that you just get an "Unable to connect" error, but you don't know why. Newer versions at least let you know that e.g. the certificate is invalid.