### PR TITLE
Various improvements

### DIFF
--- a/import.php
+++ b/import.php
@@ -207,6 +207,8 @@ global $userId;
 //download attachments
 function addAttachments($card, $cardDetails, $taskId, $projectId)
 {
+global $trellokey;
+global $trellotoken;
 global $userId;
 global $client;
 
@@ -218,15 +220,17 @@ global $client;
 			//Here is the file we are downloading, replace spaces with %20
 			$ch = curl_init($attachment->url);
 		 
-			curl_setopt($ch, CURLOPT_TIMEOUT, 50);
+			curl_setopt($ch, CURLOPT_TIMEOUT, 10);
 		 
 			//return file in variable
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 			curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+			curl_setopt($ch, CURLOPT_HTTPHEADER, ["Authorization: OAuth oauth_consumer_key=\"$trellokey\", oauth_token=\"$trellotoken\""]);
 		 
 			$data = curl_exec($ch);//get curl response
-			if ($data === false) {
+			if ($data === false || curl_error($ch)) {
 				printf('Unable to download attachment: %s%s', curl_error($ch), PHP_EOL);
+				continue;
 			}
 
 			//done

--- a/import.php
+++ b/import.php
@@ -74,6 +74,10 @@ if (!is_array($projects)) {
 	die(1);
 }
 
+//stats
+$attachmentCount = 0;
+$attachmentTotalSizeInBytes = 0;
+
 //variables
 $trelloLists = array();
 $trelloLabels = array(); //we will store all label names, but not add them immediately, only when used
@@ -160,6 +164,8 @@ foreach ($trelloObjLists as $list) {
 
 echo 'All done!' . PHP_EOL;
 echo "Project '" . $trelloObj->name . "' (projectId=$projectId)" . PHP_EOL;
+echo "  Number of attachments: {$attachmentCount}" . PHP_EOL;
+echo "  Total size of attachments: {$attachmentTotalSizeInBytes} bytes" . PHP_EOL;
 die;
 
 function addCard($projectId, $columnId, $card)
@@ -283,6 +289,8 @@ global $trellokey;
 global $trellotoken;
 global $userId;
 global $client;
+global $attachmentCount;
+global $attachmentTotalSizeInBytes;
 
 	echo "      Adding " . count($cardDetails) . " attachments..." . PHP_EOL;
 
@@ -316,11 +324,15 @@ global $client;
 			$blob = base64_encode($data);
 			$blobSize = strlen($blob);
 			echo "        Uploading $filename for task=$taskId projectId=$projectId data_size=$data_size blob size=$blobSize" . PHP_EOL;
+			$attachmentCount += 1;
+			$attachmentTotalSizeInBytes += $data_size;
+
 			$fileId = $client->createTaskFile(array('task_id' => $taskId, 'filename' => $filename, 'project_id' => $projectId, 'blob' => $blob));
 			if ($fileId === false) {
 				echo "Error uploading file!" . PHP_EOL;
 				die(1);
 			}
+			echo "        Attachment (fileId=$fileId) created" . PHP_EOL;
 		} else {
 			// just an url, add a comment
 			$text = $attachment->url;

--- a/import.php
+++ b/import.php
@@ -151,7 +151,11 @@ global $userId;
 		if (isset($trelloLabels[$trelloLabel->id])) {
 			$categoryId = $trelloLabels[$trelloLabel->id];
 		} else {
-			$categoryId = $client->createCategory($projectId, $trelloLabel->name);
+			$name = $trelloLabel->name;
+			if ($name == "") {
+				$name = "({$colorId})";
+			}
+			$categoryId = $client->createCategory($projectId, $name);
 			$trelloLabels[$trelloLabel->id] = $categoryId;
 		}
 	}

--- a/import.php
+++ b/import.php
@@ -39,6 +39,8 @@ $userId = null;
 if (isset($argv[6])) {
 	$userId = $argv[6];
 }
+// Adds the original trello user info to cards and comments
+$addTrelloUserInfo = TRUE;
 
 $jsonString = file_get_contents("https://trello.com/1/boards/".$trelloboard."?key=".$trellokey."&token=".$trellotoken);
 $trelloObj = json_decode($jsonString);
@@ -74,6 +76,17 @@ if (!is_array($projects)) {
 	die(1);
 }
 
+$dateFormatter = new IntlDateFormatter(
+		#'de_DE',
+		'en_US',
+		IntlDateFormatter::LONG,
+		IntlDateFormatter::LONG,
+		#'Europe/Berlin',
+		'America/Los_Angeles',
+		IntlDateFormatter::GREGORIAN
+);
+
+
 //stats
 $attachmentCount = 0;
 $attachmentTotalSizeInBytes = 0;
@@ -82,6 +95,7 @@ $attachmentTotalSizeInBytes = 0;
 $trelloLists = array();
 $trelloLabels = array(); //we will store all label names, but not add them immediately, only when used
 $trelloAttachments = array();
+$trelloUsers = array();
 
 //create the project
 echo "Creating project '" . $trelloObj->name . "' ..." . PHP_EOL;
@@ -168,6 +182,49 @@ echo "  Number of attachments: {$attachmentCount}" . PHP_EOL;
 echo "  Total size of attachments: {$attachmentTotalSizeInBytes} bytes" . PHP_EOL;
 die;
 
+function resolveTrelloUserId($idMember)
+{
+global $trellokey;
+global $trellotoken;
+global $trelloUsers;
+	if (isset($trelloUsers[$idMember])) {
+		return $trelloUsers[$idMember];
+	}
+
+	echo "- Resolving trello user id {$idMember}..." . PHP_EOL;
+	$jsonString = 
+			@file_get_contents("https://api.trello.com/1/members/".$idMember.
+				"?key=".$trellokey."&token=".$trellotoken."&fields=id,fullName,username");
+	if ($jsonString === FALSE) {
+		$memberDetails = "unknown";
+	} else {
+		$memberDetails = json_decode($jsonString);
+		if (empty($memberDetails)) {
+			printf($jsonString);
+			echo PHP_EOL;
+			printf('Unable to parse JSON response for memberDetails, is it valid? %s', json_last_error_msg());
+			echo PHP_EOL;
+			die(1);
+		}
+		$memberDetails = "{$memberDetails->username} ({$memberDetails->fullName})";
+	}
+	$trelloUsers[$idMember] = $memberDetails;
+	echo "  -> {$memberDetails}" . PHP_EOL;
+	return $memberDetails;
+}
+
+function formatActionMemberCreator($action)
+{
+global $dateFormatter;
+	if ($action->memberCreator) {
+		$memberDetails = "{$action->memberCreator->username} ({$action->memberCreator->fullName})";
+	} else {
+		$memberDetails = "unknown";
+	}
+	$formattedDate = $dateFormatter->format(new DateTimeImmutable($action->date));
+	return "by {$memberDetails} on {$formattedDate}";
+}
+
 function addCard($projectId, $columnId, $card)
 {
 global $trellokey;
@@ -175,11 +232,40 @@ global $trellotoken;
 global $trelloLabels;
 global $client;
 global $userId;
+global $addTrelloUserInfo;
+global $dateFormatter;
 
 	if ($card->closed) {
 		// ignore archived cards
 		echo "    card '{$card->name}' is closed/archived -> ignored." . PHP_EOL;
 		return;
+	}
+
+	# read all actions: https://developer.atlassian.com/cloud/trello/rest/api-group-boards/#api-boards-boardid-actions-get
+	# types: https://developer.atlassian.com/cloud/trello/guides/rest-api/action-types/
+	# interesting types: createCard, commentCard, copyCard, copyCommentCard
+	$jsonString = 
+		file_get_contents("https://trello.com/1/cards/".
+			$card->shortLink."/actions?key=".$trellokey."&token=".$trellotoken."&filter=createCard,commentCard,copyCard,copyCommentCard&memberCreator=true&memberCreator_fields=fullName,username&limit=200");
+	$cardActions = json_decode($jsonString);
+	if (empty($cardActions)) {
+		print_r($card);
+		printf($jsonString);
+		echo PHP_EOL;
+		printf('Unable to parse JSON response for cardActions, is it valid? %s', json_last_error_msg());
+		echo PHP_EOL;
+		die(1);
+	}
+
+	$createdInfo = "";
+	if ($addTrelloUserInfo === TRUE) {
+		foreach($cardActions as $action) {
+			if ($action->type === 'createCard') {
+				$createdInfo = "\n\n--\nCreated " . formatActionMemberCreator($action);
+			} else if ($action->type === 'copyCard') {
+				$createdInfo = "\n\n--\nCopied " . formatActionMemberCreator($action);
+			}
+		}
 	}
 
 	$dueDate = $card->due !== null ? date('Y-m-d', strtotime($card->due)) : null;
@@ -214,7 +300,7 @@ global $userId;
 		'column_id' => $columnId
 	);
 	if ($card->desc !== null) {
-		$params['description'] = $card->desc;
+		$params['description'] = $card->desc . $createdInfo;
 	}
 	if ($dueDate !== null) {
 		$params['date_due'] = $dueDate;
@@ -235,21 +321,7 @@ global $userId;
 	}
 	echo '    Added card \'' . $card->name . '\' with id ' . $taskId . PHP_EOL;
 
-	if ($card->badges->comments > 0) {
-		$jsonString = 
-			file_get_contents("https://trello.com/1/cards/".
-				$card->shortLink."/actions?key=".$trellokey."&token=".$trellotoken."&filter=all");
-		$cardDetails = json_decode($jsonString);
-		if (empty($cardDetails)) {
-			print_r($card);
-			printf($jsonString);
-			echo PHP_EOL;
-			printf('Unable to parse JSON response for cardDetails, is it valid? %s', json_last_error_msg());
-			echo PHP_EOL;
-			die(1);
-		}
-		addComments($cardDetails, $taskId);
-	}
+	addComments($cardActions, $taskId);
 
 	if ($card->badges->checkItems > 0) {
 		$jsonString = 
@@ -289,6 +361,8 @@ global $trellokey;
 global $trellotoken;
 global $userId;
 global $client;
+global $addTrelloUserInfo;
+global $dateFormatter;
 global $attachmentCount;
 global $attachmentTotalSizeInBytes;
 
@@ -336,12 +410,19 @@ global $attachmentTotalSizeInBytes;
 		} else {
 			// just an url, add a comment
 			$text = $attachment->url;
-			$commentId = $client->createComment(array('task_id' => $taskId, 'user_id' => $userId, 'content' => $text));
+			$originalAuthor = "";
+			if ($addTrelloUserInfo === TRUE) {
+				$memberDetails = resolveTrelloUserId($attachment->idMember);
+				$formattedDate = $dateFormatter->format(new DateTimeImmutable($attachment->date));
+				$originalAuthor = "\n\n--\nCreated by {$memberDetails} on {$formattedDate}";
+			}
+			$commentId = $client->createComment(array('task_id' => $taskId, 'user_id' => $userId, 'content' => $text . $originalAuthor));
 			if ($commentId === false) {
 				echo "Error creating comment for attachment (task_id=$taskId, user_id=$userId, content=$text)!" . PHP_EOL;
 				print_r($attachment);
 				die(1);
 			}
+			echo "        Created comment for attachment (id=$commentId)" . PHP_EOL;
 		}
 	}
 }
@@ -369,15 +450,31 @@ $statusDone = 2;
 	}
 }
 
-function addComments($cardDetails, $taskId)
+function addComments($cardActions, $taskId)
 {
 global $userId;
 global $client;
-	echo "      Adding " . count($cardDetails) . " comments..." . PHP_EOL;
-	foreach ($cardDetails as $comment) {
-		if ($comment->type === 'commentCard') {
+global $addTrelloUserInfo;
+global $dateFormatter;
+	$commentCount = 0;
+	foreach ($cardActions as $action) {
+		if ($action->type === 'commentCard' || $action->type === 'copyCommentCard') {
+			$commentCount += 1;
+		}
+	}
+	if ($commentCount === 0) {
+		return;
+	}
+
+	echo "      Adding {$commentCount} comments..." . PHP_EOL;
+	foreach ($cardActions as $comment) {
+		if ($comment->type === 'commentCard' || $comment->type === 'copyCommentCard') {
 			$text = $comment->data->text;
-			$commentId = $client->createComment(array('task_id' => $taskId, 'user_id' => $userId, 'content' => $text));
+			$originalAuthor = "";
+			if ($addTrelloUserInfo === TRUE) {
+				$originalAuthor = "\n\n--\nComment created " . formatActionMemberCreator($comment);
+			}
+			$commentId = $client->createComment(array('task_id' => $taskId, 'user_id' => $userId, 'content' => $text . $originalAuthor));
 			if ($commentId === false) {
 				echo "Error creating comment! (task_id=$taskId, user_id=$userId, content length=" . strlen($text) . ")" . PHP_EOL;
 				die(1);

--- a/import.php
+++ b/import.php
@@ -26,7 +26,7 @@ if ($argc !== 6 && $argc !== 7) {
 	echo 'Use this small tool to import your Trello JSON export into your kanboard, using it JSON-RPC interface.' . PHP_EOL;
 	printf('Usage: php %s http://server/jsonrpc.php apitoken trellokey trellotoken trelloboard [userId]%s', $argv[0], PHP_EOL);
 	echo 'To get the Trello key and token, login to Trello and go to https://trello.com/app-key'.PHP_EOL;
-	echo 'The user id is optional. If you provide it, comments will be created with that userId.'.PHP_EOL;
+	echo 'The user id is optional. If you provide it, cards and comments will be created with that userId.'.PHP_EOL;
 	die;
 }
 
@@ -88,6 +88,16 @@ $projectId = $client->createProject($trelloObj->name.$counter++);
 //  die("We could not create the project, perhaps it already exists?".PHP_EOL);
 }
 echo "Created project '" . $trelloObj->name . "' (projectId=$projectId)" . PHP_EOL;
+
+if ($userId !== null) {
+	$projectPermission = $client->addProjectUser($projectId, $userId, 'project-manager');
+	if ($projectPermission === TRUE) {
+		echo " Add user $userId as project-manager" . PHP_EOL;
+	} else {
+		echo " Could not add user $userId as project-manager!" . PHP_EOL;
+		die(1);
+	}
+}
 
 //remove the columns created by default
 $columns = $client->getColumns($projectId);
@@ -209,10 +219,9 @@ global $userId;
 	if ($categoryId !== null) {
 		$params['category_id'] = $categoryId;
 	}
-	//TODO temporary disabled, seems to cause errors when addings tasks in later Kanboard versions >1.0.30
-	/*if ($userId !== null) {
-		$params['owner_id'] = $userId;
-	}*/
+	if ($userId !== null) {
+		$params['creator_id'] = $userId;
+	}
 	$taskId = $client->createTask($params);
 	if ($taskId === false) {
 		echo "Error creating task! " . print_r($params, true) . PHP_EOL;

--- a/import.php
+++ b/import.php
@@ -44,7 +44,9 @@ $jsonString = file_get_contents("https://trello.com/1/boards/".$trelloboard."?ke
 $trelloObj = json_decode($jsonString);
 if (empty($trelloObj)) {
 	printf($jsonString);
-	printf('Unable to parse JSON response, is it valid? %s', json_last_error_msg());
+	echo PHP_EOL;
+	printf('Unable to parse JSON response for trelloObj, is it valid? %s', json_last_error_msg());
+	echo PHP_EOL;
 	die(1);
 }
 
@@ -78,13 +80,14 @@ $trelloLabels = array(); //we will store all label names, but not add them immed
 $trelloAttachments = array();
 
 //create the project
-echo 'Creating project.' . PHP_EOL;
+echo "Creating project '" . $trelloObj->name . "' ..." . PHP_EOL;
 $projectId = $client->createProject($trelloObj->name);
 $counter=0;
 while (empty($projectId)) {
 $projectId = $client->createProject($trelloObj->name.$counter++);
 //  die("We could not create the project, perhaps it already exists?".PHP_EOL);
 }
+echo "Created project '" . $trelloObj->name . "' (projectId=$projectId)" . PHP_EOL;
 
 //remove the columns created by default
 $columns = $client->getColumns($projectId);
@@ -101,23 +104,44 @@ if ($trelloObj->prefs->permissionLevel=="private") {
 # will only get lists that are not archived
 $jsonString = file_get_contents("https://trello.com/1/boards/".$trelloboard."/lists?key=".$trellokey."&token=".$trellotoken);
 $trelloObjLists = json_decode($jsonString);
+if (empty($trelloObjLists)) {
+	printf($jsonString);
+	echo PHP_EOL;
+	printf('Unable to parse JSON response for trelloObjLists, is it valid? %s', json_last_error_msg());
+	echo PHP_EOL;
+	die(1);
+}
+
 
 //add the lists
-echo 'Adding lists.' . PHP_EOL;
+echo "Found " . count($trelloObjLists) . " lists" . PHP_EOL;
 foreach ($trelloObjLists as $list) {
 	if ($list->closed) {
 		// ignore archived lists
+		echo "  List {$list->name} is closed/archived. Ignored!" . PHP_EOL;
 		continue;
 	}
-	echo 'Creating list '.$list->name.PHP_EOL;
+	echo '  Creating list "' . $list->name . '"' . PHP_EOL;
 	$columnId = $client->addColumn($projectId, $list->name);
+	if ($columnId === false) {
+		echo "Error creating column! (projectId=$projectId, name='{$list->name}')" . PHP_EOL;
+		die(1);
+	}
 	$trelloLists[$list->id] = $columnId;
 
 	//add each card
-	echo 'Adding cards.' . PHP_EOL;
-        $query="https://trello.com/1/lists/".$list->id."?key=".$trellokey."&token=".$trellotoken."&cards=open&card_fields=all&card_checklists=all&members=all&member_fields=all&membersInvited=all&checklists=all&organization=true&organization_fields=all&fields=all"; // &actions=commentCard,copyCommentCard&card_attachments=true";
-        $jsonCards = file_get_contents($query);
+	$query="https://trello.com/1/lists/".$list->id."?key=".$trellokey."&token=".$trellotoken."&cards=open&card_fields=all&card_checklists=all&members=all&member_fields=all&membersInvited=all&checklists=all&organization=true&organization_fields=all&fields=all"; // &actions=commentCard,copyCommentCard&card_attachments=true";
+	$jsonCards = file_get_contents($query);
 	$trelloObjCards = json_decode($jsonCards);
+	if (empty($trelloObjCards)) {
+		printf($jsonString);
+		echo PHP_EOL;
+		printf('Unable to parse JSON response for trelloObjCards, is it valid? %s', json_last_error_msg());
+		echo PHP_EOL;
+		die(1);
+	}
+
+	echo "  Found " . count($trelloObjCards->cards) . " cards..." . PHP_EOL;
 
 	foreach ($trelloObjCards->cards as $card) {
 		addCard($projectId, $columnId, $card);
@@ -125,6 +149,7 @@ foreach ($trelloObjLists as $list) {
 }
 
 echo 'All done!' . PHP_EOL;
+echo "Project '" . $trelloObj->name . "' (projectId=$projectId)" . PHP_EOL;
 die;
 
 function addCard($projectId, $columnId, $card)
@@ -137,6 +162,7 @@ global $userId;
 
 	if ($card->closed) {
 		// ignore archived cards
+		echo "    card '{$card->name}' is closed/archived -> ignored." . PHP_EOL;
 		return;
 	}
 
@@ -156,6 +182,12 @@ global $userId;
 				$name = "({$colorId})";
 			}
 			$categoryId = $client->createCategory($projectId, $name);
+			if ($categoryId === false) {
+				echo "Error creating category! projectId=$projectId, name='$name'" . PHP_EOL;
+				print_r($card);
+				die(1);
+			}
+			echo "    Created category id=$categoryId projectId=$projectId name='$name'" . PHP_EOL;
 			$trelloLabels[$trelloLabel->id] = $categoryId;
 		}
 	}
@@ -182,12 +214,25 @@ global $userId;
 		$params['owner_id'] = $userId;
 	}*/
 	$taskId = $client->createTask($params);
+	if ($taskId === false) {
+		echo "Error creating task! " . print_r($params, true) . PHP_EOL;
+		die(1);
+	}
+	echo '    Added card \'' . $card->name . '\' with id ' . $taskId . PHP_EOL;
 
 	if ($card->badges->comments > 0) {
 		$jsonString = 
 			file_get_contents("https://trello.com/1/cards/".
 				$card->shortLink."/actions?key=".$trellokey."&token=".$trellotoken."&filter=all");
 		$cardDetails = json_decode($jsonString);
+		if (empty($cardDetails)) {
+			print_r($card);
+			printf($jsonString);
+			echo PHP_EOL;
+			printf('Unable to parse JSON response for cardDetails, is it valid? %s', json_last_error_msg());
+			echo PHP_EOL;
+			die(1);
+		}
 		addComments($cardDetails, $taskId);
 	}
 
@@ -196,6 +241,13 @@ global $userId;
 			file_get_contents("https://trello.com/1/cards/".
 				$card->shortLink."/checklists?key=".$trellokey."&token=".$trellotoken);
 		$cardDetails = json_decode($jsonString);
+		if (empty($cardDetails)) {
+			printf($jsonString);
+			echo PHP_EOL;
+			printf('Unable to parse JSON response for checklists, is it valid? %s', json_last_error_msg());
+			echo PHP_EOL;
+			die(1);
+		}
 		addCheckItems($cardDetails, $taskId);
 	}
 
@@ -204,6 +256,13 @@ global $userId;
 			file_get_contents("https://trello.com/1/cards/".
 				$card->shortLink."/attachments?key=".$trellokey."&token=".$trellotoken);
 		$cardDetails = json_decode($jsonString);
+		if (empty($cardDetails)) {
+			printf($jsonString);
+			echo PHP_EOL;
+			printf('Unable to parse JSON response for attachments, is it valid? %s', json_last_error_msg());
+			echo PHP_EOL;
+			die(1);
+		}
 		addAttachments($card, $cardDetails, $taskId, $projectId);
 	}
 }
@@ -216,12 +275,15 @@ global $trellotoken;
 global $userId;
 global $client;
 
+	echo "      Adding " . count($cardDetails) . " attachments..." . PHP_EOL;
+
 	foreach ($cardDetails as $attachment) {
 		if ($attachment->isUpload) {
 			$filename = $taskId . '_' . $attachment->name;
-			printf('Downloading attachment for task %s to %s.%s', $card->name, $filename, PHP_EOL);
+			printf('        Downloading attachment for task %s to %s.%s', $card->name, $filename, PHP_EOL);
 
 			//Here is the file we are downloading, replace spaces with %20
+			echo "        Downloading from " . $attachment->url . PHP_EOL;
 			$ch = curl_init($attachment->url);
 		 
 			curl_setopt($ch, CURLOPT_TIMEOUT, 10);
@@ -234,18 +296,31 @@ global $client;
 			$data = curl_exec($ch);//get curl response
 			if ($data === false || curl_error($ch)) {
 				printf('Unable to download attachment: %s%s', curl_error($ch), PHP_EOL);
-				continue;
+				die(1);
 			}
 
 			//done
 			curl_close($ch);
 
 			// upload file as an attachment
-			$client->createTaskFile(array('task_id' => $taskId, 'filename' => $filename, 'project_id' => $projectId, 'blob' => base64_encode($data)));
+			$data_size = strlen($data);
+			$blob = base64_encode($data);
+			$blobSize = strlen($blob);
+			echo "        Uploading $filename for task=$taskId projectId=$projectId data_size=$data_size blob size=$blobSize" . PHP_EOL;
+			$fileId = $client->createTaskFile(array('task_id' => $taskId, 'filename' => $filename, 'project_id' => $projectId, 'blob' => $blob));
+			if ($fileId === false) {
+				echo "Error uploading file!" . PHP_EOL;
+				die(1);
+			}
 		} else {
 			// just an url, add a comment
 			$text = $attachment->url;
-			$client->createComment(array('task_id' => $taskId, 'user_id' => $userId, 'content' => $text));
+			$commentId = $client->createComment(array('task_id' => $taskId, 'user_id' => $userId, 'content' => $text));
+			if ($commentId === false) {
+				echo "Error creating comment for attachment (task_id=$taskId, user_id=$userId, content=$text)!" . PHP_EOL;
+				print_r($attachment);
+				die(1);
+			}
 		}
 	}
 }
@@ -259,11 +334,16 @@ global $client;
 $statusTodo = 0;
 $statusDone = 2;
 
+	echo "      Adding " . count($cardDetails) . " check lists" . PHP_EOL;
 	foreach ($cardDetails as $checkList) {
 		foreach ($checkList->checkItems as $checkItem) {
 			$title = $checkList->name . ' - ' . $checkItem->name;
 			$status = $checkItem->state === 'incomplete' ? $statusTodo : $statusDone;
-			$client->createSubtask(array('task_id' => $taskId, 'title' => $title, 'status' => $status));
+			$subtaskId = $client->createSubtask(array('task_id' => $taskId, 'title' => $title, 'status' => $status));
+			if ($subtaskId === false) {
+				echo "Error creating subtask! (task_id=$taskId, title=$title, status=$status)" . PHP_EOL;
+				die(1);
+			}
 		}
 	}
 }
@@ -272,10 +352,16 @@ function addComments($cardDetails, $taskId)
 {
 global $userId;
 global $client;
+	echo "      Adding " . count($cardDetails) . " comments..." . PHP_EOL;
 	foreach ($cardDetails as $comment) {
 		if ($comment->type === 'commentCard') {
 			$text = $comment->data->text;
-			$client->createComment(array('task_id' => $taskId, 'user_id' => $userId, 'content' => $text));
+			$commentId = $client->createComment(array('task_id' => $taskId, 'user_id' => $userId, 'content' => $text));
+			if ($commentId === false) {
+				echo "Error creating comment! (task_id=$taskId, user_id=$userId, content length=" . strlen($text) . ")" . PHP_EOL;
+				die(1);
+			}
+			echo "        Created comment (id=$commentId)" . PHP_EOL;
 		}
 	}
 }

--- a/import.php
+++ b/import.php
@@ -390,9 +390,6 @@ global $attachmentTotalSizeInBytes;
 				die(1);
 			}
 
-			//done
-			curl_close($ch);
-
 			// upload file as an attachment
 			$data_size = strlen($data);
 			$blob = base64_encode($data);


### PR DESCRIPTION
* Fixed: Attachment downloading from trello didn't work anymore. The request needs to provide the trello API key
* Fixed: Trello labels often have no name (empty string), which is not allowed as category name. Using the colorId now to create the category.
* Chore: Better Logging
* Fixed: Add the given Kanboard user as project-manager to the new project, so that the user can be the creator of the tasks.
* Chore: Count attachments and sizes - just for information purposes. The attachments need disk space...
* Feature: Add original trello user info to cards and comments (like "Created by user xyz on ... at ...") to retain this information after import
  * Note: This requires now the php extension intl, as "IntlDateFormatter" is being used.
* Chore: Remove deprecated curl_close call

